### PR TITLE
Images slow loading

### DIFF
--- a/src/components/table-tr.jsx
+++ b/src/components/table-tr.jsx
@@ -99,7 +99,9 @@ class TableTr extends Component {
                   <LocalizedLink key={i} to={data.uid + "?idx=" + i}>
                     {image.localFile && (
                       <Img
-                        fluid={image.localFile.childImageSharp.fluid}
+                        fluid={thumbnailHeight *
+                              image.localFile.childImageSharp.fluid
+                                .aspectRatio}
                         style={{
                           width:
                             thumbnailHeight *


### PR DESCRIPTION
Yo,

I was experimenting with Prismic to see if it was fast enough and the project page felt slow (and I was blaming Prismic CDN) but I found out it might be a srcset sizes problem... maybe you can have a look at this ?

Cheers